### PR TITLE
Update SEO description

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -8,7 +8,7 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="Web site created using create-react-app"
+      content="DragnCards is a free online multiplayer card game platform, and is not affiliated with or endorsed by FFG or any other company in any way."
     />
     <link rel="apple-touch-icon" href="logo192.png" />
     <!--


### PR DESCRIPTION
I noticed, posting the URL on a forum, the description still cite create-react-app, which seems a little odd. I assume the first line of the "about section" would be better