### PR TITLE
Fix: Menu items responsive for larger screens

### DIFF
--- a/frontend/src/css/custom-dropdown.css
+++ b/frontend/src/css/custom-dropdown.css
@@ -81,7 +81,6 @@
   
   .dropdown {
     position: absolute;
-    width: 300px;
     /* transform: translateX(-45%); */
     background-color: var(--bg);
     border: var(--border);
@@ -122,7 +121,7 @@
   }
 
   .menu-item {
-    height: 30px;
+    height: 3.0vh;
     display: flex;
     align-items: center;
     border-radius: var(--border-radius);
@@ -170,3 +169,4 @@
   
     transition: height var(--speed) ease;
   }
+  

--- a/frontend/src/css/custom-utilities.css
+++ b/frontend/src/css/custom-utilities.css
@@ -184,7 +184,7 @@ padding: 0;
 
 .third-level-menu > li
 {
-    height: 35px;
+    
     background: rgb(75, 85, 99);
     padding-left: 10px;
     padding-top: 5px;
@@ -206,7 +206,7 @@ padding: 0;
 .second-level-menu > li
 {
     position: relative;
-    height: 35px;
+    height: 3.0vh;
     background: rgb(75, 85, 99);
     z-index: 10000;
     padding-left: 10px;

--- a/frontend/src/features/plugins/lotrlcg/components/DropdownMenuGroup.js
+++ b/frontend/src/features/plugins/lotrlcg/components/DropdownMenuGroup.js
@@ -52,12 +52,11 @@ export const DropdownMenuGroup = React.memo(({
   }
 
   const left = mouseX < (window.innerWidth/2)  ? mouseX : mouseX -300;
-  const top = mouseY < (window.innerHeight/2) ? mouseY : mouseY -300;
 
   return (
     <div 
       className="dropdown" 
-      style={{ height: menuHeight, zIndex: 1e7, top: top, left: left }}
+      style={{ height: menuHeight, zIndex: 1e7, bottom: 5, left: left }}
       >
         <div className="menu-title">{dropdownMenuObj.title}</div>
 

--- a/frontend/src/features/plugins/lotrlcg/components/TopBarViewItem.css
+++ b/frontend/src/features/plugins/lotrlcg/components/TopBarViewItem.css
@@ -1,0 +1,7 @@
+.top-bar-item-with-count {
+    display: "flex";
+    justify-content: "space-between";
+    align-items: "center";
+    padding-left: "10px";
+    padding-right: "10px";
+}

--- a/frontend/src/features/plugins/lotrlcg/components/TopBarViewItem.js
+++ b/frontend/src/features/plugins/lotrlcg/components/TopBarViewItem.js
@@ -3,6 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { GROUPSINFO } from "../definitions/constants";
 import { setBrowseGroupId, setBrowseGroupTopN } from "../../../store/playerUiSlice";
 import { useGameL10n } from "../../../../hooks/useGameL10n";
+import "./TopBarViewItem.css"
 
 export const TopBarViewItem = React.memo(({
   groupId,
@@ -30,11 +31,13 @@ export const TopBarViewItem = React.memo(({
   if (deckType === "play") return;
 
   return(
-    <li className="relative cursor-pointer" onClick={() => handleMenuClick({action:"look_at",groupId:groupId})} key={groupId}>
-    <a className="absolute" href="#">
-    {l10n(GROUPSINFO[groupId].name)}
-    </a>
-    <div className="absolute right-2 top-1 select-none">{stackIds.length}</div>
+    <li className="relative cursor-pointer top-bar-item-with-count" onClick={() => handleMenuClick({action:"look_at",groupId:groupId})} key={groupId}>
+      <a href="#">
+        {l10n(GROUPSINFO[groupId].name)}
+      </a>
+      <div className="select-none">
+        {stackIds.length}
+      </div>
     </li>
   )
 })


### PR DESCRIPTION
# Problem
- The menu items become vertically squished on larger than average screen sizes. 
- The player hand hamburger menu could get positioned too low down the screen, causing part of it to be hidden off the bottom of the page.

The following images demonstrate the vertical squishing. I forgot to get screenshots of the menu clipping off the bottom:
<img width="400" alt="TopMenuBefore" src="https://user-images.githubusercontent.com/49127678/236700819-fc0c0008-e116-4e26-94b5-2de2ae65185b.png"> <img width="400" alt="TopViewBefore" src="https://user-images.githubusercontent.com/49127678/236700822-2e135865-0f01-4796-bea4-48023b303693.png">
<img width="363" alt="PlayerHandBefore" src="https://user-images.githubusercontent.com/49127678/236700823-529b22f9-452c-4e52-9c3a-90c0b15357be.png">

# Solution
- Change the menu item heights to `3.0vh` to make the size a bit more responsive to the screen's size
- Remove the dropdown width of `300px` to remove the arbitrary limit. The text content will determine the width naturally
- Change the position of the bottom hamburger menu to use the `bottom` property which will place the menu relative to the bottom of its container (in this case, the edge of the screen) instead of the `top` property which was pushing too far down from the top of the page. This way, it simply gets pushed a few pixels up from the bottom, which prevents the overflow. 
  - I somewhat arbitrarily chose 5px from the bottom. It's simple enough and looks fine. The specific number is purely up to taste. If you want a different amount, feel free to ask.

Here are a couple of screenshots showing the fix for the vertical squishing:
<img width="400" alt="TopMenuAfter" src="https://user-images.githubusercontent.com/49127678/236701259-278e6384-ff7c-4105-8205-9abc5639635e.png"> <img width="400" alt="TopViewAfter" src="https://user-images.githubusercontent.com/49127678/236701263-e3ee81f2-12b3-4d38-ac82-0ffd5d2b50bc.png">

# Additional Notes
After looking through some of the styling, I feel there is room for additional refactoring. Overall, I personally believe that there is "too much" styling happening. As a rule of thumb, I've found that "less is more" holds true with CSS. That being said, I don't have a full understanding of the codebase and I'm sure there are many moving parts to the current styling.
I'd be willing to help with a potential refactor, but I don't want to step on any toes. For now, I'll just stick with small-scale, specific changes that fix immediate problems.