### PR TITLE
Simple Docker Compose setup for running locally

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "elixirLS.projectDir": "backend"
+}

--- a/backend/config/dev.exs
+++ b/backend/config/dev.exs
@@ -5,7 +5,7 @@ config :dragncards, DragnCards.Repo,
   username: "postgres",
   password: "postgres",
   database: "dragncards_dev",
-  hostname: "localhost",
+  hostname: System.get_env("DB_HOSTNAME", "localhost"),
   show_sensitive_data_on_connection_error: true,
   pool_size: 10
 

--- a/backend/scripts/local-dev.sh
+++ b/backend/scripts/local-dev.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Make sure hex is installed
+mix local.hex --force
+
+# Get deps
+mix deps.get
+
+# Do any DB migration
+mix ecto.setup
+
+# Start the server
+mix phx.server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,37 @@
+services:
+  postgres:
+    image: postgres
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_DB=postgres
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+  backend:
+    image: elixir:1.14.4
+    depends_on: 
+      - postgres
+    ports:
+      - "4000:4000"
+    volumes:
+      - ./backend:/app
+    entrypoint: /app/scripts/local-dev.sh
+    working_dir: /app
+    environment:
+      - DB_HOSTNAME=postgres
+  frontend:
+    image: node:20
+    depends_on: 
+      - backend
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./frontend:/app
+    entrypoint: /app/scripts/local-dev.sh
+    working_dir: /app
+    environment:
+      - REACT_APP_BE_HOSTNAME=backend
+volumes:
+  pgdata:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
         "@emotion/core": "^10.0.28",
@@ -12364,6 +12365,7 @@
         "wrappy",
         "yallist"
       ],
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"
@@ -26152,7 +26154,6 @@
       "version": "11.1.3",
       "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-11.1.3.tgz",
       "integrity": "sha512-8rtzzT8iwHgdSC89VktwhqdKKtfXaAyC4wiqp0SywpHG12TTLvfOoL6xNEIUWXwIEWu+CFfDn4GZJyynCEuHIQ==",
-      "peer": true,
       "dependencies": {
         "@react-dnd/shallowequal": "^2.0.0",
         "@types/hoist-non-react-statics": "^3.3.1",
@@ -29909,6 +29910,7 @@
         "wrappy",
         "yallist"
       ],
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"
@@ -31010,6 +31012,7 @@
         "wrappy",
         "yallist"
       ],
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"
@@ -54283,6 +54286,7 @@
         "frontend-collective-react-dnd-scrollzone": "^1.0.2",
         "lodash.isequal": "^4.5.0",
         "prop-types": "^15.6.1",
+        "react-dnd": "^11.1.3",
         "react-dnd-html5-backend": "^11.1.3",
         "react-lifecycles-compat": "^3.0.4",
         "react-virtualized": "^9.21.2"
@@ -54299,9 +54303,9 @@
           }
         },
         "react-dnd": {
-          "version": "https://registry.npmjs.org/react-dnd/-/react-dnd-11.1.3.tgz",
+          "version": "11.1.3",
+          "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-11.1.3.tgz",
           "integrity": "sha512-8rtzzT8iwHgdSC89VktwhqdKKtfXaAyC4wiqp0SywpHG12TTLvfOoL6xNEIUWXwIEWu+CFfDn4GZJyynCEuHIQ==",
-          "peer": true,
           "requires": {
             "@react-dnd/shallowequal": "^2.0.0",
             "@types/hoist-non-react-statics": "^3.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -87,8 +87,10 @@
   "scripts": {
     "start-elixir": "REACT_APP_WS_URL=ws://172.22.2.174:4000/socket npm-run-all -p start:css start:js",
     "start": "REACT_APP_WS_URL=ws://127.0.0.1:4000/socket npm-run-all -p start:js",
+    "start:docker": "npm-run-all -p start:css start:js:docker",
     "build": "npm-run-all build:js",
     "start:js": "react-scripts start",
+    "start:js:docker": "REACT_APP_DB_HOSTNAME=backend react-scripts --openssl-legacy-provider start",
     "build:js": "react-scripts build",
     "start:css": "postcss src/css/tailwind.src.css -o src/css/tailwind.compiled.css -w",
     "build:css": "postcss src/css/tailwind.src.css -o src/css/tailwind.compiled.css --env production",
@@ -97,7 +99,8 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "lint": "eslint src --ext .js,.jsx,.ts,.tsx",
-    "prettier": "prettier --write src"
+    "prettier": "prettier --write src",
+    "cleandeps": "rm -rf node_modules"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/frontend/scripts/local-dev.sh
+++ b/frontend/scripts/local-dev.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# install deps
+npm i
+
+# start running
+npm run start:docker

--- a/frontend/src/setupProxy.js
+++ b/frontend/src/setupProxy.js
@@ -1,10 +1,12 @@
 const { createProxyMiddleware } = require("http-proxy-middleware");
 
+const hostname = process.env.REACT_APP_BE_HOSTNAME || "localhost";
+
 module.exports = function (app) {
   app.use(
     "/be",
     createProxyMiddleware({
-      target: "http://localhost:4000",
+      target: "http://" + hostname + ":4000",
       changeOrigin: true,
       pathRewrite: { "^/be": "" },
     })


### PR DESCRIPTION
On this branch, you should be able to run the following two commands to have the whole setup running without installing any dependencies:

`docker compose up -d backend`
`docker compose run --rm --service-ports frontend`

Note that the very first time you run `docker compose up -d backend`, you'll need to create a demo user, so you'll want to run

`docker compose exec backend mix run /app/priv/create_user.exs`