### PR TITLE
(V2) Fix: use room slug in download state filename

### DIFF
--- a/frontend/src/features/engine/TopBarMenu.js
+++ b/frontend/src/features/engine/TopBarMenu.js
@@ -204,7 +204,7 @@ export const TopBarMenu = React.memo(({}) => {
   const downloadGameAsJson = () => {
     const state = store.getState();
     const exportObj = state.gameUi.game;
-    const exportName = state.gameUi.roomName;
+    const exportName = state.gameUi.roomSlug;
     var dataStr = "data:text/json;charset=utf-8," + encodeURIComponent(JSON.stringify(exportObj));
     var downloadAnchorNode = document.createElement('a');
     downloadAnchorNode.setAttribute("href",     dataStr);


### PR DESCRIPTION
Fixes:

- When downloading game state, the default file name is now "undefined.json" instead of using the room slug

! Not tested locally

Microscopic PR but thought I'd have fun looking into the code a little bit; and as I can't install VirtualBox on the machine I'm using (for reasons), I can't test locally, so I'm limited to tiny things like this that I can determine from browser Developer Tools ^^'