### PR TITLE
[chore] Update Dockerfile dependencies to current stable versions

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,15 +1,15 @@
 # build environment
-FROM node:13-alpine as build
+FROM node:20-alpine AS build
 WORKDIR /app
-ENV PATH /app/node_modules/.bin:$PATH
+ENV PATH=/app/node_modules/.bin:$PATH
 COPY package.json /app/package.json
-RUN npm install --silent
-#RUN npm install react-scripts@3.2.0 -g --silent
+RUN npm install --legacy-peer-deps --silent
 COPY . /app
-RUN npm run build
+# compile tailwind CSS then build JS bundle
+RUN npm run build:css && npm run build
 
 # production environment
-FROM nginx:1.17-alpine
+FROM nginx:1.25-alpine
 COPY --from=build /app/build /usr/share/nginx/html
 RUN rm /etc/nginx/conf.d/default.conf
 COPY nginx/nginx.conf /etc/nginx/conf.d


### PR DESCRIPTION
### Summary

Updates the Dockerfile to replace End-of-Life base images with current stable versions, fixes a deprecated Dockerfile syntax, and makes the Tailwind CSS compilation step explicit.

### Changes

**Dockerfile**

| Component | Before | After | Reason |
|---|---|---|---|
| Node.js | `node:13-alpine` | `node:20-alpine` | Node 13 reached EOL in April 2021 — security risk in production. Node 20 is the current LTS. |
| nginx | `nginx:1.17-alpine` | `nginx:1.25-alpine` | nginx 1.17 is EOL. 1.25 is the current stable branch with security patches. |
| `npm install` | no flag | `--legacy-peer-deps` | npm 9+ (bundled with Node 20) enforces strict peer dependency resolution. This flag restores the previous npm 6 behavior and avoids install failures with the existing dependency tree. |
| `ENV PATH` syntax | `ENV PATH /app/...` | `ENV PATH=/app/...` | The space-separated `ENV` form is deprecated in current Docker best practices. The `KEY=value` form is preferred. |
| CSS build | implicit | `npm run build:css && npm run build` | Tailwind CSS compilation must be run explicitly before the JS bundle build. In newer Node environments this step is not automatically triggered, causing the production build to ship without styles. |
| Dead code | `#RUN npm install react-scripts@3.2.0 -g --silent` | removed | Stale commented-out line, no longer relevant. |

### Why now

Both `node:13` and `nginx:1.17` have been EOL for several years and receive no security updates. Running production containers on EOL base images is a known supply-chain risk. This PR brings the frontend build and serve images to supported, actively maintained versions with no functional changes to the application itself.